### PR TITLE
Feat/ip address

### DIFF
--- a/src/app/api/musics/route.ts
+++ b/src/app/api/musics/route.ts
@@ -1,12 +1,27 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { generateUserId } from '@/utils/password';
 
 export const revalidate = 0;
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const ipAddress = request.headers.get('x-forwarded-for');
+  const userId = generateUserId(ipAddress ?? '0.0.0.0');
+  const defaultId = generateUserId();
+
   const res = await prisma.music.findMany({
     orderBy: {
       createdAt: 'asc'
+    },
+    where: {
+      OR: [
+        {
+          userId
+        },
+        {
+          userId: defaultId
+        }
+      ]
     }
   });
   return NextResponse.json(res);

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,0 +1,9 @@
+import crypto from 'crypto';
+
+export const generateUserId = (ip: string = '0.0.0.0') => {
+  const salt = process.env.IP_ADDRESS_SALT;
+  return crypto
+    .createHash('md5')
+    .update(ip + salt, 'utf-8')
+    .digest('hex');
+};


### PR DESCRIPTION
### 🎉 변경 사항
유저 ip address에 따라 음원을 가져옵니다.


0. 공통
* `default` 또는 유저 `ip address` 에 해당하는 음원들을 모두 가져옵니다.
*  user id 를 ip address와 salt를 이용해서 id를 생성합니다.


2. 개발 환경일 시
`headers.get('x-forwarded-for')` 가 null 값으로 넘어옵니다
nullish value일 경우 '0.0.0.0` 을 사용합니다

3. 배포 환경
headers.get('x-forwarded-for') 요청한 ip가 담겨져옵니다.



